### PR TITLE
34 no order model

### DIFF
--- a/fit_basic_model.py
+++ b/fit_basic_model.py
@@ -69,8 +69,6 @@ def main(args=sys.argv[1:]):
     mutations = dict.fromkeys(motif_list, 0)
     appearances = dict.fromkeys(motif_list, 0)
 
-    # TODO: this doesn't do anything clever with overlapping mutations. Should we
-    # double count them?
     for obs_seq in obs_data:
         mutated_positions = obs_seq.mutation_pos_dict.keys()
         germline_motifs = feat_generator.create_for_sequence(obs_seq.start_seq)


### PR DESCRIPTION
Looks pretty consistent. Showing `(pos, fivemer, theta, number_mutated, number_seen)`.

```
(1, 'aaaat', 4.3082656982962808, 1, 2)
(121, 'atgct', 4.3276738182783356, 1, 2)
(151, 'acttg', 4.3258392110356398, 1, 2)
(194, 'agaac', 3.4560972865763584, 1, 4)
(252, 'aggga', 3.066948657745352, 1, 6)
(302, 'tacgc', 4.2073896046292063, 1, 2)
(500, 'tggta', 2.9664343568226905, 1, 6)
(628, 'ctgta', 3.5608366308524984, 1, 4)
(631, 'ctgtg', 2.7444335670792928, 1, 8)
(880, 'gtgaa', 3.4853822205514113, 1, 4)
(925, 'gctgt', 3.0792801767713263, 1, 6)
(1024, 'EDGES', 2.0206703026249424, 1, 16)
```