### PR TITLE
Fix simulations to use IGKV

### DIFF
--- a/get_hedgehog/sconscript
+++ b/get_hedgehog/sconscript
@@ -62,9 +62,9 @@ def process_data(env, outdir, c):
 
 motif_params_dict = [
     {
-        'motif_length': '5',
-        'left_motif_flanks': '2',
-        'penalty_params': ",".join(map(str, np.power(10, np.arange(-2.5, -7.0, step=-.5)).tolist())),
+        'motif_length': '3,5',
+        'left_motif_flanks': '1:2',
+        'penalty_params': ",".join(map(str, np.power(10, np.arange(-1.5, -5.0, step=-.5)).tolist())),
     },
 ]
 
@@ -101,25 +101,28 @@ def fit_survival(env, outdir, c):
            '--penalty-params',
            penalty_params,
            '--num-cpu-threads',
-           4,
+           10,
            '--num-jobs',
            10,
            '--burn-in',
-           2,
+           16,
            '--num-e-samples',
            4,
+           '--sampling-rate',
+           8,
            '--em-max-iters',
-           15,
+           10,
            '--num-val-burnin',
-           2,
+           16,
            '--num-val-samples',
-           4,
+           16,
            '--scratch-directory',
            SCRATCH_DIR,
            '--out-file ${TARGETS[0]}',
            '--log-file ${TARGETS[1]}',
            '--tuning-sample-ratio',
-           0.1,
+           0.2,
+           '--validation-col germline_family',
            ]
     if c["per_target"]:
         cmd += ['--per-target-model']

--- a/simulate_germline.py
+++ b/simulate_germline.py
@@ -27,7 +27,7 @@ class GermlineSimulatorPartis:
         self.organism = organism
         self.output_dir = output_dir
         self.allele_freq_file = self.output_dir + "/allele_freq.csv"
-        self.ighv_file = self.output_dir + "/igh/ighv.fasta"
+        self.ig_file = self.output_dir + "/igk/igkv.fasta"
 
     def generate_germline_sets(self, num_sets=1, n_genes_per_region="20:1:1", n_sim_alleles_per_gene="1,2:1:1", min_sim_allele_prevalence_freq=0.1):
         """
@@ -53,7 +53,7 @@ class GermlineSimulatorPartis:
         return germline_seqs_dict
 
     def _generate_germline_set(self, n_genes_per_region="20:1:1", n_sim_alleles_per_gene="1,2:1:1", min_sim_allele_prevalence_freq=0.1):
-        glfo = glutils.read_glfo(self.GERMLINE_FOLDER + "/"  + self.organism, "igh")
+        glfo = glutils.read_glfo(self.GERMLINE_FOLDER + "/"  + self.organism, "igk")
         glutils.generate_germline_set(glfo, n_genes_per_region, n_sim_alleles_per_gene, min_sim_allele_prevalence_freq, self.allele_freq_file)
         glutils.write_glfo(self.output_dir, glfo)
 
@@ -63,12 +63,12 @@ class GermlineSimulatorPartis:
             allele_reader = csv.reader(f)
             allele_reader.next()
             for row in allele_reader:
-                if row[0].startswith("IGHV"):
+                if row[0].startswith("IGKV"):
                     germline_freqs[row[0]] = float(row[1])
 
         # Read the selected germline alleles
         germline_seqs = dict()
-        with open(self.ighv_file, "r") as f:
+        with open(self.ig_file, "r") as f:
             lines = f.read().splitlines()
             for line_idx in range(len(lines)/2):
                 allele = lines[line_idx * 2].replace(">", "")

--- a/simulated_shazam_vs_samm/sconscript
+++ b/simulated_shazam_vs_samm/sconscript
@@ -33,7 +33,7 @@ nest.add(
 
 nest.add(
     'replicate',
-    range(2,3),
+    range(1),
     label_func='{:02d}'.format)
 
 # Set the seed to be the replicate number.
@@ -154,20 +154,20 @@ def fit_survival(env, outdir, c):
         c['simulate'],
         ' '.join(map(str, cmd)))
 
-#@nest.add_target_with_env(localenv)
-#def fit_shazam(env, outdir, c):
-#
-#    cmd = ['python fit_shmulate_model.py',
-#           '--input-file',
-#           '${SOURCES[0]}',
-#           '--input-genes',
-#           '${SOURCES[1]}',
-#           '--model-pkl ${TARGETS[0]}',
-#           '--log-file ${TARGETS[1]}']
-#
-#    return env.Command(
-#        [join(outdir, 'fitted_shazam.pkl'), join(outdir, 'log_shazam.txt')],
-#        c['simulate'],
-#        ' '.join(map(str, cmd)))
+@nest.add_target_with_env(localenv)
+def fit_shazam(env, outdir, c):
+
+    cmd = ['python fit_shmulate_model.py',
+           '--input-file',
+           '${SOURCES[0]}',
+           '--input-genes',
+           '${SOURCES[1]}',
+           '--model-pkl ${TARGETS[0]}',
+           '--log-file ${TARGETS[1]}']
+
+    return env.Command(
+        [join(outdir, 'fitted_shazam.pkl'), join(outdir, 'log_shazam.txt')],
+        c['simulate'],
+        ' '.join(map(str, cmd)))
 
 # Compare models using compare_simulated_shazam_vs_samm.py

--- a/simulated_shazam_vs_samm/sconscript
+++ b/simulated_shazam_vs_samm/sconscript
@@ -39,7 +39,7 @@ nest.add(
 # Set the seed to be the replicate number.
 nest.add(
     'seed',
-    [0], # FORCING SEEED TO BE SAME.
+    [0],
     #lambda c: [c['replicate']],
     create_dir=False)
 
@@ -154,20 +154,20 @@ def fit_survival(env, outdir, c):
         c['simulate'],
         ' '.join(map(str, cmd)))
 
-@nest.add_target_with_env(localenv)
-def fit_shazam(env, outdir, c):
-
-    cmd = ['python fit_shmulate_model.py',
-           '--input-file',
-           '${SOURCES[0]}',
-           '--input-genes',
-           '${SOURCES[1]}',
-           '--model-pkl ${TARGETS[0]}',
-           '--log-file ${TARGETS[1]}']
-
-    return env.Command(
-        [join(outdir, 'fitted_shazam.pkl'), join(outdir, 'log_shazam.txt')],
-        c['simulate'],
-        ' '.join(map(str, cmd)))
+#@nest.add_target_with_env(localenv)
+#def fit_shazam(env, outdir, c):
+#
+#    cmd = ['python fit_shmulate_model.py',
+#           '--input-file',
+#           '${SOURCES[0]}',
+#           '--input-genes',
+#           '${SOURCES[1]}',
+#           '--model-pkl ${TARGETS[0]}',
+#           '--log-file ${TARGETS[1]}']
+#
+#    return env.Command(
+#        [join(outdir, 'fitted_shazam.pkl'), join(outdir, 'log_shazam.txt')],
+#        c['simulate'],
+#        ' '.join(map(str, cmd)))
 
 # Compare models using compare_simulated_shazam_vs_samm.py


### PR DESCRIPTION
Realized that the real data is IGKV, not IGHV. So the simulations should also use IGKV.

Also, is there a big difference between using IGHV vs IGKV? It seems like using IGKV is improving our simulation results (e.g. we're getting confidence intervals it seems). Is there more entropy in the nucleotide sequences for IGKV?