### PR TITLE
Keep running EM iterations until hessian only has nonneg variance estimates

### DIFF
--- a/context_model_algo.py
+++ b/context_model_algo.py
@@ -153,7 +153,8 @@ class ContextModelAlgo:
             zero_theta_mask=model_masks.zero_theta_mask_refit,
             burn_in=self.burn_in,
             penalty_params=(0,0), # now fit with no penalty
-            max_em_iters=max_em_iters,
+            max_em_iters=2 * max_em_iters if get_hessian else max_em_iters,
+            max_hessian_iters=max_em_iters,
             max_e_samples=self.num_e_samples * 4,
             get_hessian=get_hessian,
             pool=pool

--- a/fit_samm.py
+++ b/fit_samm.py
@@ -345,8 +345,9 @@ def main(args=sys.argv[1:]):
             for col_idx in range(num_agg_cols):
                 full_theta, theta_lower, theta_upper = feat_generator_stage2.combine_thetas_and_get_conf_int(
                     method_res.refit_theta,
-                    sample_obs_info=method_res.sample_obs_info,
+                    variance_est=method_res.variance_est,
                     col_idx=col_idx + agg_start_col,
+                    add_targets=args.per_target_model,
                 )
         except ValueError as e:
             print(e)

--- a/mcmc_em.py
+++ b/mcmc_em.py
@@ -142,5 +142,5 @@ class MCMC_EM:
                                 add_targets=self.per_target_model)
                     break
                 except ValueError as e:
-                    log.info("found negative variance estimates.. mcmc iteration %d, ERROR: %s", run, e)
+                    log.info("found negative variance estimates.. EM iteration %d, ERROR: %s", run, e)
         return theta, variance_est, sample_obs_info, all_traces


### PR DESCRIPTION
This may sound a bit hacky, but it's not actually that bad. The reason the hessian has negative variance estimates can be due to the fact that the the current estimate for theta is not close enough to a local maxima. Then the assumptions about the gradient of the expected complete data log likelihood may not hold. If we keep running EM iterations, this issue will be relieved.

The other reason we added this is that we used to have two different estimators of the hessian and 99% of the time, one of them will work. The latest code, which sped up the hessian calculations, only has a single estimator of the hessian and this might not always give nonneg variance estimates.  It seems to be a noise/optimization-error issue. Therefore we can resolve this issue by running EM until the hessian starts looking reasonable.